### PR TITLE
China financial videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | 战旗TV   | <http://www.zhanqi.tv/lives>   |✓| | |
 | 央视网   | <http://www.cntv.cn/>          |✓| | |
 | 花瓣     | <http://huaban.com/>           | |✓| |
+| 东方财富  | <http://video.eastmoney.com/>          |✓| | |
+
 
 For all other sites not on the list, the universal extractor will take care of finding and downloading interesting resources from the page.
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | 央视网   | <http://www.cntv.cn/>          |✓| | |
 | 花瓣     | <http://huaban.com/>           | |✓| |
 | 东方财富  | <http://video.eastmoney.com/>          |✓| | |
+| 第一财经  | <http://www.yicai.com/video/>          |✓| | |
 
 
 For all other sites not on the list, the universal extractor will take care of finding and downloading interesting resources from the page.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | 花瓣     | <http://huaban.com/>           | |✓| |
 | 东方财富  | <http://video.eastmoney.com/>          |✓| | |
 | 第一财经  | <http://www.yicai.com/video/>          |✓| | |
+| 中金在线  | <http://video.cnfol.com/>          |✓| | |
 
 
 For all other sites not on the list, the universal extractor will take care of finding and downloading interesting resources from the page.

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -87,7 +87,8 @@ SITES = {
     'youtu'            : 'youtube',
     'youtube'          : 'youtube',
     'zhanqi'           : 'zhanqi',
-    'eastmoney'   : 'eastmoney'
+    'eastmoney'   : 'eastmoney',
+    'yicai'   : 'yicai'
 }
 
 import getopt

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -87,6 +87,7 @@ SITES = {
     'youtu'            : 'youtube',
     'youtube'          : 'youtube',
     'zhanqi'           : 'zhanqi',
+    'eastmoney'   : 'eastmoney'
 }
 
 import getopt

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -88,7 +88,8 @@ SITES = {
     'youtube'          : 'youtube',
     'zhanqi'           : 'zhanqi',
     'eastmoney'   : 'eastmoney',
-    'yicai'   : 'yicai'
+    'yicai'   : 'yicai',
+    'cnfol'   : 'cnfol'
 }
 
 import getopt

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -75,3 +75,4 @@ from .youku import *
 from .youtube import *
 from .ted import *
 from .khan import *
+from .eastmoney import *

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -77,3 +77,4 @@ from .ted import *
 from .khan import *
 from .eastmoney import *
 from .yicai import *
+from .cnfol import *

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -76,3 +76,4 @@ from .youtube import *
 from .ted import *
 from .khan import *
 from .eastmoney import *
+from .yicai import *

--- a/src/you_get/extractors/cnfol.py
+++ b/src/you_get/extractors/cnfol.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+__all__ = ['cnfol_download']
+
+from ..common import *
+
+def cnfol_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
+    if "video.cnfol.com" in url:
+        html = get_content(url)
+        title = match1(html, r'<h1>(.+)</h1>')
+        url = match1(html, r"{f:'([^']+)'")
+        _, ext, size = url_info(url)
+        print_info(site_info, title, ext, size)
+        if not info_only:
+            download_urls([url], title, ext, size, output_dir = output_dir, merge = merge)
+
+site_info = "video.cnfol.com"
+download = cnfol_download
+download_playlist = playlist_not_supported('cnfol')

--- a/src/you_get/extractors/eastmoney.py
+++ b/src/you_get/extractors/eastmoney.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+__all__ = ['eastmoney_download']
+
+from ..common import *
+
+def eastmoney_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
+    if "video.eastmoney.com" in url:
+        html = get_content(url)
+        title = match1(html, r'<h1>(.+)</h1>')
+        src = match1(html, r'src="http://player.kankanews.com/embed/([^"]+)"')
+        frame_url = 'http://player.kankanews.com/embed/' + src
+        frame_html = get_content(frame_url)
+        url = match1(frame_html, r'var mp4 = "([^"]+)"')
+        _, ext, size = url_info(url)
+        print_info(site_info, title, ext, size)
+        if not info_only:
+            download_urls([url], title, ext, size, output_dir = output_dir, merge = merge)
+
+site_info = "video.eastmoney.com"
+download = eastmoney_download
+download_playlist = playlist_not_supported('eastmoney')

--- a/src/you_get/extractors/yicai.py
+++ b/src/you_get/extractors/yicai.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+__all__ = ['yicai_download']
+
+from ..common import *
+
+def yicai_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
+    if "www.yicai.com" in url:
+        url = url.replace('www.yicai.com','m.yicai.com')
+        html = get_content(url)
+        title = match1(html, r'<h1 class="f-ff3">(.+)</h1>')
+        url = match1(html, r'<source.+?src="([^"]+)"')
+        _, ext, size = url_info(url)
+        print_info(site_info, title, ext, size)
+        if not info_only:
+            download_urls([url], title, ext, size, output_dir = output_dir, merge = merge)
+
+site_info = "*.yicai.com/video"
+download = yicai_download
+download_playlist = playlist_not_supported('yicai')


### PR DESCRIPTION
For Test:

东方财富   <http://video.eastmoney.com/>  

```bash
./you-get -i http://video.eastmoney.com/news/1609,20160408612456177.html
Site:       video.eastmoney.com
Title:      婷婷创立：Fit Time――Hold住你的人生，从Hold住身体开始！
Type:       MPEG-4 video (video/mp4)
Size:       72.65 MiB (76178903 Bytes)
```

中金在线   <http://video.cnfol.com/>      
(It will fail on some weird page from this site, the problem and solution is here: https://github.com/soimort/you-get/pull/1116)

```bash
./you-get --debug -i http://video.cnfol.com/anxinshiye/20160505/22700157.shtml
[DEBUG] get_content: http://video.cnfol.com/anxinshiye/20160505/22700157.shtml
Site:       video.cnfol.com
Title:      朱力解盘：隔夜外围再跌 A股面临选择
Type:       MPEG-4 video (video/mp4)
Size:       26.78 MiB (28075962 Bytes)
```

第一财经  <http://www.yicai.com/video/>   


```bash
./you-get --debug -i http://www.yicai.com/video/5011500.html
[DEBUG] get_content: http://m.yicai.com/video/5011500.html
Site:       *.yicai.com/video
Title:      【首席对策】吴敬琏：证券市场的繁荣不是靠“放水”
Type:       MPEG-4 video (video/mp4)
Size:       65.04 MiB (68195260 Bytes)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1117)
<!-- Reviewable:end -->
