### PR TITLE
add function any_download_info, which returns video info if it is pos…

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1263,6 +1263,12 @@ def url_to_module(url):
         else:
             return import_module('you_get.extractors.universal'), url
 
+def any_download_info(url, **kwargs):
+    m, url = url_to_module(url)
+    m.download(url, **kwargs)
+    if hasattr(m, '_info'):
+        return m._info
+
 def any_download(url, **kwargs):
     m, url = url_to_module(url)
     m.download(url, **kwargs)


### PR DESCRIPTION
Sometimes, we use you_get as a lib imported in my code, and I need to store the video info to somewhere else, instead of just print out.

with this any_download_info function, we are able perform such action:

```Python
import you_get.common
info_we_want = you_get.common.any_download_info('http://example.com/video/xxxx',info_only=True)
store_info(info_we_want)
```
or, we can also store it somewhere else after the video is handled
```Python
import you_get.common
info_we_want = you_get.common.any_download_info('http://example.com/video/xxxx')
store_info(info_we_want)
```

Of course, we need to set the `_info`  variable in our extractors which we need the info to be returned.